### PR TITLE
Fix opam constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: c
-sudo: required
-language: c
 sudo: false
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex ./.travis-docker.sh
 env:
   global:
-  - PINS="faraday-async:. faraday:. faraday-lwt:. faraday-lwt-unix:."
+  - PINS="faraday-async.dev:. faraday.dev:. faraday-lwt.dev:. faraday-lwt-unix.dev:."
   matrix:
   - PACKAGE="faraday" DISTRO="ubuntu-16.04" OCAML_VERSION="4.04.2"
   - PACKAGE="faraday-async" DISTRO="ubuntu-16.04" OCAML_VERSION="4.04.2"

--- a/faraday-async.opam
+++ b/faraday-async.opam
@@ -14,7 +14,7 @@ build-test: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
-  "faraday"
-  "async"
+  "faraday"  {>= "0.3.0"}
+  "async"    {>= "v0.9.0"}
 ]
 available: [ ocaml-version >= "4.02.0" ]

--- a/faraday-lwt-unix.opam
+++ b/faraday-lwt-unix.opam
@@ -14,7 +14,6 @@ build-test: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
-  "faraday"
   "faraday-lwt"
   "lwt"
   "base-unix"

--- a/faraday-lwt.opam
+++ b/faraday-lwt.opam
@@ -14,7 +14,7 @@ build-test: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
-  "faraday"
+  "faraday" {>= "0.3.0"}
   "lwt"
 ]
 available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
* `"faraday" {>= "0.3.0"}` in async and lwt packages.
* `"async" {>= "v0.9.0"}` in `faraday-async`

In addition, pin dev versions in `.travis.yml` to ensure the build works. This can probably be removed after `0.3.0` gets released.