### PR TITLE
Fix deque growth and writes larger than the buffer's size

### DIFF
--- a/lib/faraday.ml
+++ b/lib/faraday.ml
@@ -88,7 +88,7 @@ end = struct
       end else begin
         let old  = t.elements in
         let new_ = Array.(make (2 * length old) sentinel) in
-        Array.blit old t.front t.elements 0 len;
+        Array.blit old t.front new_ 0 len;
         t.elements <- new_
       end;
       t.front <- 0;

--- a/lib_test/test_faraday.ml
+++ b/lib_test/test_faraday.ml
@@ -51,16 +51,16 @@ let write =
       check ~iovecs:1 ~msg:"bytes"     [`Write_bytes     "test"] "test";
       check ~iovecs:1 ~msg:"bigstring" [`Write_bigstring "test"] "test";
       check ~iovecs:1 ~msg:"char"      [`Write_char      'A'   ] "A";
-      check ~buf_size:1 ~iovecs:4 ~msg:"string"    [`Write_string    "test"] "test";
-      check ~buf_size:1 ~iovecs:4 ~msg:"bytes"     [`Write_bytes     "test"] "test";
-      check ~buf_size:1 ~iovecs:4 ~msg:"bigstring" [`Write_bigstring "test"] "test";
+      check ~buf_size:1 ~iovecs:1 ~msg:"string"    [`Write_string    "test"] "test";
+      check ~buf_size:1 ~iovecs:1 ~msg:"bytes"     [`Write_bytes     "test"] "test";
+      check ~buf_size:1 ~iovecs:1 ~msg:"bigstring" [`Write_bigstring "test"] "test";
   end ]
 
 let write_tiny_buf =
   [ "single with tiny buffer", `Quick, begin fun () ->
-      check ~buf_size:1 ~iovecs:4 ~msg:"string"    [`Write_string    "test"] "test";
-      check ~buf_size:1 ~iovecs:4 ~msg:"bytes"     [`Write_bytes     "test"] "test";
-      check ~buf_size:1 ~iovecs:4 ~msg:"bigstring" [`Write_bigstring "test"] "test";
+      check ~buf_size:1 ~iovecs:1 ~msg:"string"    [`Write_string    "test"] "test";
+      check ~buf_size:1 ~iovecs:1 ~msg:"bytes"     [`Write_bytes     "test"] "test";
+      check ~buf_size:1 ~iovecs:1 ~msg:"bigstring" [`Write_bigstring "test"] "test";
   end ]
 
 let schedule =

--- a/lib_test/test_faraday.ml
+++ b/lib_test/test_faraday.ml
@@ -50,17 +50,14 @@ let write =
       check ~iovecs:1 ~msg:"string"    [`Write_string    "test"] "test";
       check ~iovecs:1 ~msg:"bytes"     [`Write_bytes     "test"] "test";
       check ~iovecs:1 ~msg:"bigstring" [`Write_bigstring "test"] "test";
-      check ~iovecs:1 ~msg:"char"      [`Write_char      'A'   ] "A";
-      check ~buf_size:1 ~iovecs:1 ~msg:"string"    [`Write_string    "test"] "test";
-      check ~buf_size:1 ~iovecs:1 ~msg:"bytes"     [`Write_bytes     "test"] "test";
-      check ~buf_size:1 ~iovecs:1 ~msg:"bigstring" [`Write_bigstring "test"] "test";
+      check ~iovecs:1 ~msg:"char"      [`Write_char      'A'   ] "A"
   end ]
 
 let write_tiny_buf =
   [ "single with tiny buffer", `Quick, begin fun () ->
       check ~buf_size:1 ~iovecs:1 ~msg:"string"    [`Write_string    "test"] "test";
       check ~buf_size:1 ~iovecs:1 ~msg:"bytes"     [`Write_bytes     "test"] "test";
-      check ~buf_size:1 ~iovecs:1 ~msg:"bigstring" [`Write_bigstring "test"] "test";
+      check ~buf_size:1 ~iovecs:1 ~msg:"bigstring" [`Write_bigstring "test"] "test"
   end ]
 
 let schedule =

--- a/lib_test/test_faraday.ml
+++ b/lib_test/test_faraday.ml
@@ -50,7 +50,17 @@ let write =
       check ~iovecs:1 ~msg:"string"    [`Write_string    "test"] "test";
       check ~iovecs:1 ~msg:"bytes"     [`Write_bytes     "test"] "test";
       check ~iovecs:1 ~msg:"bigstring" [`Write_bigstring "test"] "test";
-      check ~iovecs:1 ~msg:"char"      [`Write_char      'A'   ] "A"
+      check ~iovecs:1 ~msg:"char"      [`Write_char      'A'   ] "A";
+      check ~buf_size:1 ~iovecs:4 ~msg:"string"    [`Write_string    "test"] "test";
+      check ~buf_size:1 ~iovecs:4 ~msg:"bytes"     [`Write_bytes     "test"] "test";
+      check ~buf_size:1 ~iovecs:4 ~msg:"bigstring" [`Write_bigstring "test"] "test";
+  end ]
+
+let write_tiny_buf =
+  [ "single with tiny buffer", `Quick, begin fun () ->
+      check ~buf_size:1 ~iovecs:4 ~msg:"string"    [`Write_string    "test"] "test";
+      check ~buf_size:1 ~iovecs:4 ~msg:"bytes"     [`Write_bytes     "test"] "test";
+      check ~buf_size:1 ~iovecs:4 ~msg:"bigstring" [`Write_bigstring "test"] "test";
   end ]
 
 let schedule =
@@ -92,7 +102,8 @@ let interleaved =
 
 let () =
   Alcotest.run "test suite"
-    [ "empty output"      , empty
-    ; "single write"      , write
-    ; "single schedule"   , schedule
-    ; "interleaved calls" , interleaved ]
+    [ "empty output"              , empty
+    ; "single write"              , write
+    ; "single write (tiny buffer)", write
+    ; "single schedule"           , schedule
+    ; "interleaved calls"         , interleaved ]


### PR DESCRIPTION
FIrst, the deque previous code allocated a new array but wrote to the existing array.  This changes the blit to point to the newly allocated array.  The previous version caused existing array elements to be thrown out and replaced by sentinel values.

Second, writing values to a `Faraday.t` with a buffer smaller than the written value would cause `Invalid_argument` to be written due to writes outside of the buffer's bounds.

Fixes #12 
Fixes #14