### PR TITLE
allocation: be better about allocating a new buffer for writes

### DIFF
--- a/lib/faraday.ml
+++ b/lib/faraday.ml
@@ -414,8 +414,10 @@ let rec shift_buffers t written =
       Buffers.enqueue_front (IOVec.shift iovec written) t.scheduled
   with Not_found ->
     assert (written = 0);
-    t.scheduled_pos <- 0;
-    t.write_pos <- 0
+    if t.scheduled_pos = t.write_pos then begin
+      t.scheduled_pos <- 0;
+      t.write_pos <- 0
+    end
 
 let rec shift_flushes t =
   try

--- a/lib_test/test_faraday.ml
+++ b/lib_test/test_faraday.ml
@@ -58,6 +58,14 @@ let write_tiny_buf =
       check ~buf_size:1 ~iovecs:1 ~msg:"string"    [`Write_string    "test"] "test";
       check ~buf_size:1 ~iovecs:1 ~msg:"bytes"     [`Write_bytes     "test"] "test";
       check ~buf_size:1 ~iovecs:1 ~msg:"bigstring" [`Write_bigstring "test"] "test"
+  end 
+  ; "multiple writes with tiny buffer", `Quick,  begin fun () ->
+      check ~buf_size:1 ~iovecs:2 ~msg:"string" [`Write_string "test1"; `Write_string "test2"] "test1test2"
+  end
+  ; "too many writes with tiny buffer", `Quick,  begin fun () ->
+      check ~buf_size:1 ~iovecs:5 ~msg:"string"
+        [`Write_string "te"; `Write_string "st"; `Write_string "te"; `Write_string "st"; `Write_string "te" ] 
+        "testtestte"
   end ]
 
 let schedule =
@@ -101,6 +109,6 @@ let () =
   Alcotest.run "test suite"
     [ "empty output"              , empty
     ; "single write"              , write
-    ; "single write (tiny buffer)", write
+    ; "writes (tiny buffer)"      , write_tiny_buf
     ; "single schedule"           , schedule
     ; "interleaved calls"         , interleaved ]


### PR DESCRIPTION
A bugfix introduced additional buffer allocations on every flush, as the
previously code would have led to existing buffered output being
overridden on a subsequent write. This patch re-introduces the previous
allocation pattern while maintaining the bugfix. The write_pos and
scheduled_pos are only reset to zero when either all pending flushes
have been satisfied or a new buffer has been allocated.

Closes #20