### PR TITLE
bigstring-only: get rid of string and bytes as output formats

### DIFF
--- a/async/faraday_async.mli
+++ b/async/faraday_async.mli
@@ -7,9 +7,9 @@ open Faraday
 val serialize
   :  Faraday.t
   -> yield  : (t -> unit Deferred.t)
-  -> writev : (buffer iovec list -> [ `Ok of int | `Closed ] Deferred.t)
+  -> writev : (bigstring iovec list -> [ `Ok of int | `Closed ] Deferred.t)
   -> unit Deferred.t
 
 val writev_of_fd
   :  Fd.t
-  -> buffer iovec list -> [ `Ok of int | `Closed ] Deferred.t
+  -> bigstring iovec list -> [ `Ok of int | `Closed ] Deferred.t

--- a/lwt/faraday_lwt.mli
+++ b/lwt/faraday_lwt.mli
@@ -4,5 +4,5 @@ open Faraday
 val serialize
   :  t
   -> yield  : (t -> unit Lwt.t)
-  -> writev : (buffer iovec list -> [ `Ok of int | `Closed ] Lwt.t)
+  -> writev : (bigstring iovec list -> [ `Ok of int | `Closed ] Lwt.t)
   -> unit Lwt.t

--- a/lwt_unix/faraday_lwt_unix.ml
+++ b/lwt_unix/faraday_lwt_unix.ml
@@ -2,14 +2,6 @@ open Lwt
 
 include Faraday_lwt
 
-let write fd buf off len =
-  try Lwt_unix.write fd buf off len >|= fun n -> `Ok n
-  with Unix.Unix_error (Unix.EBADF, "check_descriptor", _) -> return `Closed
-
-let write_string fd buf off len =
-  try Lwt_unix.write_string fd buf off len >|= fun n -> `Ok n
-  with Unix.Unix_error (Unix.EBADF, "check_descriptor", _) -> return `Closed
-
 let write_bigstring fd buf off len =
   try Lwt_bytes.write fd buf off len >|= fun n -> `Ok n
   with Unix.Unix_error (Unix.EBADF, "check_descriptor", _) -> return `Closed
@@ -19,7 +11,5 @@ let writev_of_fd fd =
      currently does not expose a writev function. That system call should be
      bound manually at some point in the future. *)
   function
-  | []       -> assert false
-  | { Faraday.buffer = `Bytes     buf; off; len }::_ -> write           fd buf off len
-  | { Faraday.buffer = `String    buf; off; len }::_ -> write_string    fd buf off len
-  | { Faraday.buffer = `Bigstring buf; off; len }::_ -> write_bigstring fd buf off len
+  | []                              -> assert false
+  | { Faraday.buffer; off; len }::_ -> write_bigstring fd buffer off len

--- a/lwt_unix/faraday_lwt_unix.mli
+++ b/lwt_unix/faraday_lwt_unix.mli
@@ -5,4 +5,4 @@ include module type of Faraday_lwt
 
 val writev_of_fd
   :  Lwt_unix.file_descr
-  -> buffer iovec list -> [ `Ok of int | `Closed ] Lwt.t
+  -> bigstring iovec list -> [ `Ok of int | `Closed ] Lwt.t


### PR DESCRIPTION
To simplify the implementation and interface of the library, drop `string` and `bytes` as output formats. Using bigstring is the most versatile option, as they work nicely with blocking system calls. If you're into that sort of thing.