### PR TITLE
Fix serialization to string in some cases

### DIFF
--- a/lib/faraday.ml
+++ b/lib/faraday.ml
@@ -467,8 +467,8 @@ let serialize_to_string t =
     let pos = ref 0 in
     List.iter (function
       | { buffer; off; len } ->
-        for i = off to len - 1 do
-          Bytes.unsafe_set bytes (!pos + i) (Bigstring.unsafe_get buffer i)
+        for i = 0 to len - 1 do
+          Bytes.unsafe_set bytes (!pos + i) (Bigstring.unsafe_get buffer (off + i))
         done;
         pos := !pos + len)
     iovecs;


### PR DESCRIPTION
I haven't come up with a good minimal test for this, but it fixes some more slightly complex local serialization code.  Without this, in some cases when mixing different `write*` operations with `schedule_bigstring` operations, junk or null bytes would end up in the output.