### PR TITLE
Use Lwt_unix.writev

### DIFF
--- a/lwt_unix/jbuild
+++ b/lwt_unix/jbuild
@@ -5,5 +5,5 @@
   (public_name faraday-lwt-unix)
   (wrapped false)
   (libraries
-    (faraday lwt faraday-lwt))
+    (faraday lwt lwt.unix faraday-lwt))
   (flags (:standard -safe-string))))


### PR DESCRIPTION
This improves the performance of the Httpaf Lwt adapters in inhabitedtype/httpaf#53 and inhabitedtype/httpaf#54. For the latter, without this PR, a histogram can look like this:

```
Running 1m test @ http://127.0.0.1:8080
  4 threads and 10000 connections
  Thread calibration: mean lat.: 1224.531ms, rate sampling interval: 5791ms
  Thread calibration: mean lat.: 1238.365ms, rate sampling interval: 5836ms
  Thread calibration: mean lat.: 1227.386ms, rate sampling interval: 5804ms
  Thread calibration: mean lat.: 1234.312ms, rate sampling interval: 5828ms
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     7.40s     2.41s   12.68s    57.95%
    Req/Sec     5.56k   141.73     5.76k    41.67%
  Latency Distribution (HdrHistogram - Recorded Latency)
 50.000%    7.48s 
 75.000%    9.54s 
 90.000%   10.58s 
 99.000%   11.63s 
 99.900%   12.12s 
 99.990%   12.32s 
 99.999%   12.44s 
100.000%   12.69s 

Requests/sec:  20224.52
Transfer/sec:     40.39MB
```

...and with this PR:

```
Running 1m test @ http://127.0.0.1:8080
  4 threads and 10000 connections
  Thread calibration: mean lat.: 761.214ms, rate sampling interval: 2963ms
  Thread calibration: mean lat.: 755.509ms, rate sampling interval: 3112ms
  Thread calibration: mean lat.: 704.276ms, rate sampling interval: 2777ms
  Thread calibration: mean lat.: 744.756ms, rate sampling interval: 2908ms
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.19s   954.98ms   6.10s    61.56%
    Req/Sec     6.59k   186.40     6.76k    85.71%
  Latency Distribution (HdrHistogram - Recorded Latency)
 50.000%    3.29s 
 75.000%    3.96s 
 90.000%    4.35s 
 99.000%    5.16s 
 99.900%    5.63s 
 99.990%    5.84s 
 99.999%    6.00s 
100.000%    6.11s 

Requests/sec:  23635.05
Transfer/sec:     47.20MB
```

cc @paurkedal

I also made `faraday-lwt-unix` depend properly on `lwt.unix`, which is necessary since Lwt 4.0.0.