### PR TITLE
unset yield on flush

### DIFF
--- a/lib/faraday.ml
+++ b/lib/faraday.ml
@@ -203,6 +203,7 @@ let flush_buffer t =
   end
 
 let flush t f =
+  t.yield <- false;
   flush_buffer t;
   if Buffers.is_empty t.scheduled then f ()
   else Flushes.enqueue (t.bytes_received, f) t.flushed


### PR DESCRIPTION
If you ask a serializer to `yield`, then synchronously use it in such a
way that you no longer want it to yield, there is no way to "undo" the
yield aside from using `operation` twice and ignoring the first yield.
The semantics of `flush` should be that it unsets any possible `yield`
flag so that the next operation has a chance to read pending iovecs.

I did not include tests, particularly because this was difficult to
encapsulate with the given framework. We need to be able to inspect the
state of the serializer without closing it, and all current serialize
functions do close it in order to dump the contents to a string or
bigstring.