### PR TITLE
Give explicit arguments to Monitor.try_with.

### DIFF
--- a/async/faraday_async.ml
+++ b/async/faraday_async.ml
@@ -22,7 +22,10 @@ let serialize t ~yield ~writev =
       yield t >>= fun () -> loop t
     | `Close -> return ()
   in
-  try_with ~extract_exn:true (fun () -> loop t)
+  try_with
+    ~rest:`Log (* consider [`Raise] instead *)
+    ~run:`Schedule (* consider [`Now] instead *)
+    ~extract_exn:true (fun () -> loop t)
   >>| function
     | Result.Ok () -> ()
     | Result.Error exn ->


### PR DESCRIPTION
The defaults are about to change from

    ~rest:`Log ~run:`Schedule
to

    ~rest:`Raise ~run:`Now

This patch preserves the current behavior.

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>