### PR TITLE
faraday-lwt-unix: handle EPIPE the same way as BADFD is handled

### DIFF
--- a/lwt_unix/faraday_lwt_unix.ml
+++ b/lwt_unix/faraday_lwt_unix.ml
@@ -13,7 +13,8 @@ let writev_of_fd fd =
         Lwt_unix.writev fd lwt_iovecs
         >|= fun n -> `Ok n)
       (function
-      | Unix.Unix_error (Unix.EBADF, "check_descriptor", _) ->
+      | Unix.Unix_error (Unix.EBADF, "check_descriptor", _)
+      | Unix.Unix_error (Unix.EPIPE, _, _) ->
         Lwt.return `Closed
       | exn ->
         Lwt.fail exn)


### PR DESCRIPTION
The socket is closed for writing

This fixes an issue when a HTTP/AF + Opium server receives a request,
where the requestor closes the TCP connection before the response has
been sent completely. Note that the server in question ignores SIGPIPE
(which is then translated to an EPIPE): Sys.(set_signal epipe Signal_ignore)

//cc @aantron @reynir