### PR TITLE
flush_with_reason

### DIFF
--- a/lib/faraday.ml
+++ b/lib/faraday.ml
@@ -205,8 +205,8 @@ let flush_buffer t =
 let flush_with_reason t f =
   t.yield <- false;
   flush_buffer t;
-  if Buffers.is_empty t.scheduled then f `Shift
-  else Flushes.enqueue (t.bytes_received, f) t.flushed
+  if Buffers.is_empty t.scheduled then f `Nothing_pending
+  else Flushes.enqueue (t.bytes_received, (f :> [ `Shift | `Drain] -> unit)) t.flushed
 
 let flush t f = flush_with_reason t (fun _ -> f ())
 

--- a/lib/faraday.ml
+++ b/lib/faraday.ml
@@ -150,8 +150,8 @@ module Buffers = Deque(struct
     { buffer; off = 0; len }
 end)
 module Flushes = Deque(struct
-  type t = int * (unit -> unit)
-  let sentinel = 0, fun () -> ()
+  type t = int * ([ `Shift | `Drain ] -> unit)
+  let sentinel = 0, fun _ -> ()
 end)
 
 type t =
@@ -202,11 +202,13 @@ let flush_buffer t =
     t.scheduled_pos <- t.write_pos
   end
 
-let flush t f =
+let flush_with_reason t f =
   t.yield <- false;
   flush_buffer t;
-  if Buffers.is_empty t.scheduled then f ()
+  if Buffers.is_empty t.scheduled then f `Shift
   else Flushes.enqueue (t.bytes_received, f) t.flushed
+
+let flush t f = flush_with_reason t (fun _ -> f ())
 
 let free_bytes_in_buffer t =
   let buf_len = Bigstringaf.length t.buffer in
@@ -380,7 +382,7 @@ let rec shift_buffers t written =
     end else
       Buffers.enqueue_front (IOVec.shift iovec written) t.scheduled
 
-let rec shift_flushes t =
+let rec shift_flushes t ~reason =
   match Flushes.dequeue_exn t.flushed with
   | exception Dequeue_empty -> ()
   | (threshold, f) as flush ->
@@ -400,13 +402,16 @@ let rec shift_flushes t =
      * overflowed as similarly, just shifted down a bit.
      *)
     if t.bytes_written - min_int >= threshold - min_int
-    then begin f (); shift_flushes t end
+    then begin f reason; shift_flushes t ~reason end
     else Flushes.enqueue_front flush t.flushed
 
-let shift t written =
+let shift_internal t written ~reason =
   shift_buffers t written;
   t.bytes_written <- t.bytes_written + written;
-  shift_flushes t
+  shift_flushes t ~reason
+;;
+
+let shift t written = shift_internal t written ~reason:`Shift
 
 let operation t =
   if t.closed then begin
@@ -475,7 +480,7 @@ let drain =
     match operation t with
     | `Writev iovecs ->
       let len = IOVec.lengthv iovecs in
-      shift t len;
+      shift_internal t len ~reason:`Drain;
       loop t (len + acc)
     | `Close         -> acc
     | `Yield         -> loop t acc

--- a/lib/faraday.mli
+++ b/lib/faraday.mli
@@ -219,6 +219,11 @@ val flush : t -> (unit -> unit) -> unit
     of the [yield] will be ignored so that client code has an opportunity to
     write pending output, regardless of how it handles [`Yield] operations.  *)
 
+val flush_with_reason : t -> ([ `Shift | `Drain ] -> unit) -> unit
+(** [flush_with_reason t f] is like [flush t f], but [f] is suppplied with the reason that
+    the flush was triggered: either as a result of a call to [shift] or a call to [drain].
+*)
+
 val close : t -> unit
 (** [close t] closes [t]. All subsequent write calls will raise, and any
     pending or subsequent {!yield} calls will be ignored. If the serializer has

--- a/lib/faraday.mli
+++ b/lib/faraday.mli
@@ -219,9 +219,10 @@ val flush : t -> (unit -> unit) -> unit
     of the [yield] will be ignored so that client code has an opportunity to
     write pending output, regardless of how it handles [`Yield] operations.  *)
 
-val flush_with_reason : t -> ([ `Shift | `Drain ] -> unit) -> unit
+val flush_with_reason : t -> ([ `Shift | `Drain | `Nothing_pending ] -> unit) -> unit
 (** [flush_with_reason t f] is like [flush t f], but [f] is suppplied with the reason that
-    the flush was triggered: either as a result of a call to [shift] or a call to [drain].
+    the flush was triggered. [`Nothing_pending] means that [f] is being called immediately
+    because at the time of calling [flush], there were no unwritten bytes.
 *)
 
 val close : t -> unit

--- a/lib/faraday.mli
+++ b/lib/faraday.mli
@@ -219,11 +219,22 @@ val flush : t -> (unit -> unit) -> unit
     of the [yield] will be ignored so that client code has an opportunity to
     write pending output, regardless of how it handles [`Yield] operations.  *)
 
-val flush_with_reason : t -> ([ `Shift | `Drain | `Nothing_pending ] -> unit) -> unit
+module Flushed_reason : sig
+  (** Indicates why a flush callback was called. *)
+  type t =
+    | Shift
+    (** [shift t] was called, normally indicating that bytes were written successfully. *)
+    | Drain
+    (** [drain t] was called, normally indicating that the downstream consumer of [t]'s
+        bytes stopped accepting new input. *)
+    | Nothing_pending
+    (** Passed to [f] when [flush_with_reason t f] is called when there is not any pending
+        output, so [t] is considered immediately flushed. *)
+end
+
+val flush_with_reason : t -> (Flushed_reason.t -> unit) -> unit
 (** [flush_with_reason t f] is like [flush t f], but [f] is suppplied with the reason that
-    the flush was triggered. [`Nothing_pending] means that [f] is being called immediately
-    because at the time of calling [flush], there were no unwritten bytes.
-*)
+    the callback was triggered. *)
 
 val close : t -> unit
 (** [close t] closes [t]. All subsequent write calls will raise, and any

--- a/lib_test/test_faraday.ml
+++ b/lib_test/test_faraday.ml
@@ -42,16 +42,17 @@ module Operation = struct
 end
 
 module Flush_reason = struct
-  type t = [ `Shift | `Drain ]
+  type t = [ `Shift | `Drain | `Nothing_pending ]
 
   let pp_hum fmt t =
     match t with
-    | `Shift -> Format.pp_print_string fmt "Shift"
-    | `Drain -> Format.pp_print_string fmt "Drain"
+    | `Shift           -> Format.pp_print_string fmt "Shift"
+    | `Drain           -> Format.pp_print_string fmt "Drain"
+    | `Nothing_pending -> Format.pp_print_string fmt "Nothing_pending"
 
   let equal t t' =
     match t, t' with
-    | `Shift, `Shift | `Drain, `Drain -> true
+    | `Shift, `Shift | `Drain, `Drain | `Nothing_pending, `Nothing_pending -> true
     | _ -> false
 end
 
@@ -244,7 +245,7 @@ let test_flush () =
   let flush_reason = set_up_flush () in
   Alcotest.(check' (option flush_reason))
     ~msg:"flushes resolved immediately if no waiting bytes"
-    ~expected:(Some `Shift)
+    ~expected:(Some `Nothing_pending)
     ~actual:!flush_reason;
 
   write_string t "hello world";

--- a/lib_test/test_faraday.ml
+++ b/lib_test/test_faraday.ml
@@ -41,18 +41,18 @@ module Operation = struct
   ;;
 end
 
-module Flush_reason = struct
-  type t = [ `Shift | `Drain | `Nothing_pending ]
+module Flushed_reason = struct
+  type t = Flushed_reason.t
 
-  let pp_hum fmt t =
+  let pp_hum fmt (t:t) =
     match t with
-    | `Shift           -> Format.pp_print_string fmt "Shift"
-    | `Drain           -> Format.pp_print_string fmt "Drain"
-    | `Nothing_pending -> Format.pp_print_string fmt "Nothing_pending"
+    | Shift           -> Format.pp_print_string fmt "Shift"
+    | Drain           -> Format.pp_print_string fmt "Drain"
+    | Nothing_pending -> Format.pp_print_string fmt "Nothing_pending"
 
-  let equal t t' =
+  let equal (t:t) (t':t) =
     match t, t' with
-    | `Shift, `Shift | `Drain, `Drain | `Nothing_pending, `Nothing_pending -> true
+    | Shift, Shift | Drain, Drain | Nothing_pending, Nothing_pending -> true
     | _ -> false
 end
 
@@ -60,7 +60,7 @@ module Alcotest = struct
   include Alcotest
 
   let operation : Operation.t testable = testable Operation.pp_hum Operation.equal
-  let flush_reason : Flush_reason.t testable = testable Flush_reason.pp_hum Flush_reason.equal
+  let flush_reason : Flushed_reason.t testable = testable Flushed_reason.pp_hum Flushed_reason.equal
 end
 
 let test ?(buf_size=0x100) f =
@@ -245,7 +245,7 @@ let test_flush () =
   let flush_reason = set_up_flush () in
   Alcotest.(check' (option flush_reason))
     ~msg:"flushes resolved immediately if no waiting bytes"
-    ~expected:(Some `Nothing_pending)
+    ~expected:(Some Nothing_pending)
     ~actual:!flush_reason;
 
   write_string t "hello world";
@@ -258,7 +258,7 @@ let test_flush () =
   shift t 6;
   Alcotest.(check' (option flush_reason))
     ~msg:"flush during shift"
-    ~expected:(Some `Shift)
+    ~expected:(Some Shift)
     ~actual:!flush_reason;
 
   write_string t "one";
@@ -268,11 +268,11 @@ let test_flush () =
   shift t 6;
   Alcotest.(check' (option flush_reason))
     ~msg:"flush during shift past the flush point"
-    ~expected:(Some `Shift)
+    ~expected:(Some Shift)
     ~actual:!flush_reason1;
   Alcotest.(check' (option flush_reason))
     ~msg:"flush during shift past the flush point"
-    ~expected:(Some `Shift)
+    ~expected:(Some Shift)
     ~actual:!flush_reason2;
 
   write_string t "hello world";
@@ -281,7 +281,7 @@ let test_flush () =
   ignore (drain t : int);
   Alcotest.(check' (option flush_reason))
     ~msg:"flush during drain"
-    ~expected:(Some `Drain)
+    ~expected:(Some Drain)
     ~actual:!flush_reason;
 ;;
 

--- a/lib_test/test_faraday.ml
+++ b/lib_test/test_faraday.ml
@@ -41,10 +41,25 @@ module Operation = struct
   ;;
 end
 
+module Flush_reason = struct
+  type t = [ `Shift | `Drain ]
+
+  let pp_hum fmt t =
+    match t with
+    | `Shift -> Format.pp_print_string fmt "Shift"
+    | `Drain -> Format.pp_print_string fmt "Drain"
+
+  let equal t t' =
+    match t, t' with
+    | `Shift, `Shift | `Drain, `Drain -> true
+    | _ -> false
+end
+
 module Alcotest = struct
   include Alcotest
 
   let operation : Operation.t testable = testable Operation.pp_hum Operation.equal
+  let flush_reason : Flush_reason.t testable = testable Flush_reason.pp_hum Flush_reason.equal
 end
 
 let test ?(buf_size=0x100) f =
@@ -134,7 +149,7 @@ let write =
   [ "char"           , `Quick, char
   ; "single w/ room" , `Quick, (write : unit -> unit)
   ; "single w/o room", `Quick, write ~buf_size:1
-  ; "multiple"       , `Quick, write_multiple 
+  ; "multiple"       , `Quick, write_multiple
   ]
 
 let schedule () =
@@ -217,6 +232,60 @@ let interleaved serialize =
       [`Write_char 't'; `Write_bytes "t"; `Write_string "t"])
   end ]
 
+let test_flush () =
+  let t = create 0x100 in
+
+  let set_up_flush () =
+    let flush_reason = ref None in
+    flush_with_reason t (fun reason -> flush_reason := Some reason);
+    flush_reason
+  in
+
+  let flush_reason = set_up_flush () in
+  Alcotest.(check' (option flush_reason))
+    ~msg:"flushes resolved immediately if no waiting bytes"
+    ~expected:(Some `Shift)
+    ~actual:!flush_reason;
+
+  write_string t "hello world";
+  let flush_reason = set_up_flush () in
+  shift t 5;
+  Alcotest.(check' (option flush_reason))
+    ~msg:"flush not yet resolved as not enough bytes shifted"
+    ~expected:None
+    ~actual:!flush_reason;
+  shift t 6;
+  Alcotest.(check' (option flush_reason))
+    ~msg:"flush during shift"
+    ~expected:(Some `Shift)
+    ~actual:!flush_reason;
+
+  write_string t "one";
+  let flush_reason1 = set_up_flush () in
+  write_string t "two";
+  let flush_reason2 = set_up_flush () in
+  shift t 6;
+  Alcotest.(check' (option flush_reason))
+    ~msg:"flush during shift past the flush point"
+    ~expected:(Some `Shift)
+    ~actual:!flush_reason1;
+  Alcotest.(check' (option flush_reason))
+    ~msg:"flush during shift past the flush point"
+    ~expected:(Some `Shift)
+    ~actual:!flush_reason2;
+
+  write_string t "hello world";
+  close t;
+  let flush_reason = set_up_flush () in
+  ignore (drain t : int);
+  Alcotest.(check' (option flush_reason))
+    ~msg:"flush during drain"
+    ~expected:(Some `Drain)
+    ~actual:!flush_reason;
+;;
+
+let flush = [ "flush", `Quick, test_flush ]
+
 let () =
   Alcotest.run "test suite"
     [ "empty output"                  , empty
@@ -224,4 +293,6 @@ let () =
     ; "write"                         , write
     ; "single schedule"               , schedule
     ; "interleaved calls (string)"    , interleaved serialize_to_string
-    ; "interleaved calls (bigstring)" , interleaved serialize_to_bigstring']
+    ; "interleaved calls (bigstring)" , interleaved serialize_to_bigstring'
+    ; "flush"                         , flush
+    ]


### PR DESCRIPTION
Adds a new function to the interface, ``flush_with_reason : t -> ([ `Shift | `Drain ] -> unit) -> unit``, which is like `flush` but it gives the callback information on why it is being called.