### PR TITLE
[drain] would loop infinitely if no bytes were currently pending.

### DIFF
--- a/lib/faraday.ml
+++ b/lib/faraday.ml
@@ -477,7 +477,6 @@ let drain =
       let len = IOVec.lengthv iovecs in
       shift t len;
       loop t (len + acc)
-    | `Close         -> acc
-    | `Yield         -> loop t acc
+    | `Close | `Yield -> acc
   in
   fun t -> loop t 0


### PR DESCRIPTION
This PR fixes this and adds some tests for the [drain] function.