### PR TITLE
faraday-async  limit iovecs to iovec max

### DIFF
--- a/async/faraday_async.ml
+++ b/async/faraday_async.ml
@@ -32,17 +32,6 @@ let serialize t ~yield ~writev =
       shutdown ();
       raise exn
 
-let limit_iovecs_length_to_iov_max iovecs =
-  match Unix.sysconf Unix.IOV_MAX with
-  | None -> iovecs
-  | Some iov_max ->
-    match Int64.to_int iov_max with
-    | None -> iovecs
-    | Some iov_max ->
-    match List.length iovecs with
-    | l when l > iov_max -> List.sub iovecs ~pos:0 ~len:iov_max
-    | _ -> iovecs
-
 let writev_of_fd fd =
   let badfd =
     failwithf "writev_of_fd got bad fd: %s" (Fd.to_string fd)
@@ -66,7 +55,6 @@ let writev_of_fd fd =
       raise exn
   in
   fun iovecs ->
-    let iovecs = limit_iovecs_length_to_iov_max iovecs in
     let iovecs = Array.of_list_map iovecs ~f:(fun iovec ->
       let { Faraday.buffer; off = pos; len } = iovec in
       Unix.IOVec.of_bigstring ~pos ~len buffer)


### PR DESCRIPTION
I discovered that when using faraday-async while trying to serve large files with httpaf, the writev() syscall to fail with EINVAL because iovcnt was greater than IOV_MAX on my system (Linux).  

Lwt works just fine without this patch because [Lwt_unix.writev] does this automatically while [Bigstring_unix.writev] which ultimately gets called on the Async side is more naive and defaults to just slamming whatever iovecs array you give it into writev(). 
I tried calling [Bigstring_unx.writev] with the optional count argument but that didn't seem to work while this patch did.   

A better solution might be to patch [Bigstring_unix.writev] to be smarter about this mirroring the Lwt approach.   