### PR TITLE
Fix compatibility with core >= 0.15

### DIFF
--- a/async/dune
+++ b/async/dune
@@ -1,5 +1,5 @@
 (library
  (name        faraday_async)
  (public_name faraday-async)
- (libraries   faraday async)
+ (libraries   faraday async core_unix)
  (flags (:standard -safe-string)))

--- a/async/faraday_async.ml
+++ b/async/faraday_async.ml
@@ -1,7 +1,7 @@
 open Core
 open Async
 
-module Unix = Core.Unix
+module Unix = Core_unix
 
 
 let serialize t ~yield ~writev =

--- a/faraday-async.opam
+++ b/faraday-async.opam
@@ -15,6 +15,7 @@ depends: [
   "dune" {>= "1.11"}
   "faraday" {>= "0.5.0"}
   "core" {>= "v0.14.0"}
+  "core_unix" {>= "v0.14.0"}
   "async" {>= "v0.14.0"}
 ]
 synopsis: "Async support for Faraday"


### PR DESCRIPTION
Just fixes for the removal of `Core.Unix` in 0.15